### PR TITLE
fix: change configs and cache file extension for version 41.78.20

### DIFF
--- a/media/lua/client/CHC_config.lua
+++ b/media/lua/client/CHC_config.lua
@@ -83,7 +83,8 @@ local init_cfg = {
     favorites = {
         items = { sep_x = 500, filter_asc = true, filter_type = 'all' },
         recipes = { sep_x = 500, filter_asc = true, filter_type = 'all' }
-    }
+    },
+    migrated = true
 }
 
 local init_mappings = {
@@ -366,21 +367,34 @@ CHC_settings.Load = function()
 end
 
 CHC_settings.migrateConfig = function()
+    --Check if the config already has migrated
+    local cfgStatus, cfg = pcall(utils.tableutil.load, config_name)
+    if cfgStatus and cfg and cfg.migrated then return end
+
     local oldName = "craft_helper_config.json"
+    local oldName2 = "craft_helper_config.lua"
+    local defaultStr = "Safe to remove"
+
     local oldCfgr = getFileReader(oldName, false)
     if not oldCfgr then return end
     oldCfgr:close()
     local status, oldConfig = pcall(utils.jsonutil.Load, oldName)
-    if not status then return end
-    --Do not change the old file, as it cannot be overwritten
-    --local defaultStr = "Safe to remove"
-    --utils.jsonutil.Save(oldName, { defaultStr })
-    if not oldConfig or
-        utils.empty(oldConfig) or
-        oldConfig[1] == defaultStr then
-        return
+    local status2, oldConfig2 = pcall(utils.tableutil.load, oldName2)
+    
+    if not status and not status2 then return end
+
+    if status then
+        --Check if the file is empty or was already copied
+        if not oldConfig or utils.empty(oldConfig) or oldConfig[1] == defaultStr then return end
+        oldConfig.migrated = true
+        utils.tableutil.save(config_name, oldConfig)
     end
-    utils.tableutil.save(config_name, oldConfig)
+    if status2 then
+        --Check if the file is empty or was already copied
+        if not oldConfig2 or utils.empty(oldConfig2) then return end
+        oldConfig2.migrated = true
+        utils.tableutil.save(config_name, oldConfig2)
+    end
 end
 
 CHC_settings.checkConfig = function(config)

--- a/media/lua/client/CHC_config.lua
+++ b/media/lua/client/CHC_config.lua
@@ -5,8 +5,8 @@ require 'CHC_config_apply_funcs'
 local utils = require('CHC_utils')
 
 local dir = utils.configDir
-local config_name = 'craft_helper_config.lua'
-local mappings_name = 'CHC_mappings.json'
+local config_name = 'craft_helper_config.cfg'
+local mappings_name = 'CHC_mappings.cfg'
 
 local char = string.char
 local byte = string.byte
@@ -106,8 +106,8 @@ local applyBlacklist = {
 }
 
 local presetStorageToFilename = {
-    presets = 'CHC_presets.lua',
-    filters = 'CHC_filter_presets.lua'
+    presets = 'CHC_presets.cfg',
+    filters = 'CHC_filter_presets.cfg'
 }
 
 function CHC_settings.f.onModOptionsApply(values)

--- a/media/lua/client/CHC_config.lua
+++ b/media/lua/client/CHC_config.lua
@@ -372,8 +372,9 @@ CHC_settings.migrateConfig = function()
     oldCfgr:close()
     local status, oldConfig = pcall(utils.jsonutil.Load, oldName)
     if not status then return end
-    local defaultStr = "Safe to remove"
-    utils.jsonutil.Save(oldName, { defaultStr })
+    --Do not change the old file, as it cannot be overwritten
+    --local defaultStr = "Safe to remove"
+    --utils.jsonutil.Save(oldName, { defaultStr })
     if not oldConfig or
         utils.empty(oldConfig) or
         oldConfig[1] == defaultStr then

--- a/media/lua/client/CHC_main.lua
+++ b/media/lua/client/CHC_main.lua
@@ -31,7 +31,7 @@ local cnt = 0
 
 CheckMyModTable = CheckMyModTable or {} -- Mod Checker
 CheckMyModTable[CHC_main._meta.id] = CHC_main._meta.workshopId
-local cacheFileName = 'CraftHelperLuaCache.json'
+local cacheFileName = 'CraftHelperLuaCache.cfg'
 local loadLua = true
 
 local showTime = function(start, st)

--- a/media/lua/client/CHC_main.lua
+++ b/media/lua/client/CHC_main.lua
@@ -31,7 +31,7 @@ local cnt = 0
 
 CheckMyModTable = CheckMyModTable or {} -- Mod Checker
 CheckMyModTable[CHC_main._meta.id] = CHC_main._meta.workshopId
-local cacheFileName = 'CraftHelperLuaCache.cfg'
+local cacheFileName = 'CraftHelperLuaCache.txt'
 local loadLua = true
 
 local showTime = function(start, st)

--- a/media/lua/client/CHC_utils.lua
+++ b/media/lua/client/CHC_utils.lua
@@ -432,7 +432,7 @@ end
 
 ---comment
 ---@param fname string Filename to save data to
----@param data table Data to save
+---@param data table|boolean|string Data to save
 CHC_utils.tableutil.save = function(fname, data)
     if not data then return end
     local fileWriterObj = getFileWriter(fname, true, false)

--- a/media/lua/client/UI/CHC_menu.lua
+++ b/media/lua/client/UI/CHC_menu.lua
@@ -18,7 +18,7 @@ CHC_menu.init = function()
 end
 
 CHC_menu.applyMigrations = function()
-    --region configs from .json to .lua
+    --region configs from .json to .cfg
     CHC_settings.migrateConfig()
     --endregion
 


### PR DESCRIPTION
On the last B41 update that launched on 07/29/2026 (41.78.20), TIS added a check to the extensions of files created with the `getFileWriter()`. Now it only allows creating .txt, .ini and .cfg. (maybe other but I didn't test it)
This PR only aims at changing the extensions of all files created by the mod to be .cfg.
Tested it and worked fine.

I did a fast temporary solution, by posting a patch on the workshop, so that I could use it on my server.
If you someday update your mod, I will remove mine from the workshop.